### PR TITLE
[Fix] Fix GitHub Actions CI test failures

### DIFF
--- a/internal/bucket/service.go
+++ b/internal/bucket/service.go
@@ -408,17 +408,17 @@ func validateBucketName(name string) error {
 		return s3errors.ErrInvalidBucketName.WithMessage("bucket name must be between 3 and 63 characters")
 	}
 
-	if !bucketNameRegex.MatchString(name) {
-		return s3errors.ErrInvalidBucketName.WithMessage("bucket name can only contain lowercase letters, numbers, hyphens, and periods")
-	}
-
-	// Additional checks
+	// Check for leading/trailing dots and hyphens before regex
 	if name[0] == '.' || name[len(name)-1] == '.' {
 		return s3errors.ErrInvalidBucketName.WithMessage("bucket name cannot start or end with a period")
 	}
 
 	if name[0] == '-' || name[len(name)-1] == '-' {
 		return s3errors.ErrInvalidBucketName.WithMessage("bucket name cannot start or end with a hyphen")
+	}
+
+	if !bucketNameRegex.MatchString(name) {
+		return s3errors.ErrInvalidBucketName.WithMessage("bucket name can only contain lowercase letters, numbers, hyphens, and periods")
 	}
 
 	// Cannot look like an IP address
@@ -429,6 +429,7 @@ func validateBucketName(name string) error {
 
 	return nil
 }
+
 
 // FindMatchingCORSRule finds a CORS rule that matches the given origin and method
 func (s *Service) FindMatchingCORSRule(rules []metadata.CORSRule, origin, method string) *metadata.CORSRule {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1030,7 +1030,7 @@ func setDefaults(v *viper.Viper) {
 
 	// Placement groups defaults
 	v.SetDefault("storage.placement_groups.local_group_id", "default")
-	v.SetDefault("storage.placement_groups.min_nodes_for_erasure", 3)
+	v.SetDefault("storage.placement_groups.min_nodes_for_erasure", 14)
 
 	// Cache defaults (DRAM Cache)
 	v.SetDefault("cache.enabled", false)

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -42,10 +42,18 @@ func (m *MockMetadataStore) GetClusterInfo(ctx context.Context) (*metadata.Clust
 }
 
 func (m *MockMetadataStore) IsLeader() bool {
+	// Handle nil receiver (when metadata store itself is nil)
+	if m == nil {
+		return false
+	}
 	return m.isLeader
 }
 
 func (m *MockMetadataStore) LeaderAddress() (string, error) {
+	// Handle nil receiver (when metadata store itself is nil)
+	if m == nil {
+		return "", s3errors.ErrInternalError
+	}
 	if m.leaderAddress == "" {
 		return "", s3errors.ErrInternalError
 	}
@@ -53,6 +61,10 @@ func (m *MockMetadataStore) LeaderAddress() (string, error) {
 }
 
 func (m *MockMetadataStore) ListBuckets(ctx context.Context, owner string) ([]*metadata.Bucket, error) {
+	// Handle nil receiver (when metadata store itself is nil)
+	if m == nil {
+		return nil, s3errors.ErrInternalError
+	}
 	if m.listBucketsErr != nil {
 		return nil, m.listBucketsErr
 	}
@@ -113,6 +125,10 @@ type MockStorageBackend struct {
 }
 
 func (m *MockStorageBackend) GetStorageInfo(ctx context.Context) (*backend.StorageInfo, error) {
+	// Handle nil receiver (when storage backend itself is nil)
+	if m == nil {
+		return nil, s3errors.ErrInternalError
+	}
 	if m.storageInfoErr != nil {
 		return nil, m.storageInfoErr
 	}


### PR DESCRIPTION
## Summary

This PR fixes three categories of CI test failures that were blocking the GitHub Actions pipeline:

### 1. TestValidateBucketName (internal/bucket)
**Problem**: 4 test cases were failing for bucket names starting/ending with dots and hyphens
- Tests expected specific error messages: "cannot start or end with a period/hyphen"
- But bucketNameRegex was evaluated first, returning generic "can only contain lowercase letters..." message

**Fix**: Moved dot/hyphen validation checks BEFORE the regex validation
- Now returns correct specific error messages as expected by tests
- File: `internal/bucket/service.go`

### 2. Config Validation (internal/config)  
**Problem**: All config tests failing with error: "min_nodes_for_erasure (3) is less than total shards required (10 data + 4 parity = 14)"

**Fix**: Updated default `min_nodes_for_erasure` from 3 to 14
- Erasure coding defaults: 10 data shards + 4 parity shards = 14 total
- Validation requires `min_nodes_for_erasure >= total_shards`
- File: `internal/config/config.go`

### 3. Health Test Panics (internal/health)
**Problem**: TestCheckStorage/nil_storage and other tests panicking with nil pointer dereference
- Tests pass `nil` for mock storage/metadata to test error handling
- Go interface quirk: interface containing typed nil pointer is NOT nil, but calling methods panics

**Fix**: Added nil receiver checks to all mock methods
- MockStorageBackend.GetStorageInfo()
- MockMetadataStore: IsLeader(), LeaderAddress(), ListBuckets()
- File: `internal/health/health_test.go`

## Test Results

All three affected packages now pass:
```
✅ ok  	github.com/piwi3910/nebulaio/internal/bucket	
✅ ok  	github.com/piwi3910/nebulaio/internal/config	
✅ ok  	github.com/piwi3910/nebulaio/internal/health	
```

## Checklist
- [x] All affected tests pass locally
- [x] No new linting errors introduced
- [x] Changes are minimal and focused on fixing the failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)