### PR TITLE
[Fix] Fix golangci-lint errors

### DIFF
--- a/internal/audit/enhanced.go
+++ b/internal/audit/enhanced.go
@@ -975,7 +975,11 @@ func (o *FileOutput) compressFile(filePath string) {
 		log.Warn().Err(err).Str("file", filePath).Msg("Failed to open log file for compression")
 		return
 	}
-	defer inFile.Close()
+	defer func() {
+		if err := inFile.Close(); err != nil {
+			log.Warn().Err(err).Str("file", filePath).Msg("Failed to close log file after compression")
+		}
+	}()
 
 	// Create the compressed file
 	compressedPath := filePath + ".gz"

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -323,25 +323,6 @@ func TestVersionVariable(t *testing.T) {
 	assert.Equal(t, "dev", Version)
 }
 
-// Helper function for benchmarks
-func resetAllMetrics() {
-	RequestsTotal.Reset()
-	RequestDuration.Reset()
-	ObjectsTotal.Reset()
-	BucketsTotal.Set(0)
-	StorageBytesUsed.Set(0)
-	StorageBytesTotal.Set(0)
-	ActiveConnections.Set(0)
-	RaftState.Reset()
-	RaftIsLeader.Reset()
-	RaftProposalLatency.Reset()
-	RaftProposalsTotal.Reset()
-	MultipartUploadsActive.Set(0)
-	ErrorsTotal.Reset()
-	S3OperationsTotal.Reset()
-	ClusterNodesTotal.Set(0)
-}
-
 func BenchmarkRecordRequest(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		RecordRequest("GET", "GetObject", 200, 10*time.Millisecond)


### PR DESCRIPTION
## Summary

This PR fixes two golangci-lint errors that were causing CI lint failures:

### 1. Errcheck: Unchecked error from inFile.Close()
**File**: `internal/audit/enhanced.go:978`

**Problem**: defer inFile.Close() was not checking the error return value

**Fix**: Wrapped in defer func() to properly check and log close errors:
```go
defer func() {
    if err := inFile.Close(); err != nil {
        log.Warn().Err(err).Str("file", filePath).Msg("Failed to close log file after compression")
    }
}()
```

### 2. Unused: resetAllMetrics() function
**File**: `internal/metrics/metrics_test.go:327`

**Problem**: Helper function `resetAllMetrics()` was defined but never called

**Fix**: Removed the unused function

## Test Results

Linting now passes locally:
```bash
$ golangci-lint run --timeout=5m
0 issues.
```

## Related

- This fixes the remaining linting errors after PR #99 was merged
- PR #99 fixed the test failures, this PR fixes the linting errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)